### PR TITLE
New features: Caching of assets and Nailgun support

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,13 @@ Configure plugin in `book.json`.
 ```
 "pluginsConfig": {
   "uml": {
-    format: 'png'
+    format: 'png',
+    nailgun: false
   }
 }
 ```
+
+The plugin can be configured to use [Nailgun](http://martiansoftware.com/nailgun/) but by default it does not.
 
 ## Build and serve
 

--- a/index.js
+++ b/index.js
@@ -35,12 +35,14 @@ function processBlock(blk) {
         var assetPath = ASSET_PATH;
         var filePath = assetPath + crypto.createHash('sha1').update(code).digest('hex') + '.' + format;
 
-        fs.mkdirpSync(assetPath);
+        if (!fs.existsSync(filePath)) {
+            fs.mkdirpSync(assetPath);
 
-        fs.writeFile(filePath, buffer, (err) => {
-            if (err)
+            fs.writeFile(filePath, buffer, (err) => {
+                if (err)
                 console.error(err);
-        });
+            });
+        }
 
         var result = "<img src=/" + filePath + ">";
         deferred.resolve(result);

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ module.exports = {
                     format: 'png'
                 });
             }
-            var startNailgun = this.book.config.get('plugins.uml.nailgun', false);
+            var startNailgun = this.book.config.get('pluginsConfig.uml.nailgun', false);
             if (startNailgun && !nailgunRunning) {
                 plantuml.useNailgun(function() {
                     nailgunRunning = true;

--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ var crypto = require('crypto');
 var plantuml = require('node-plantuml');
 var Q = require('q');
 
+var nailgunRunning = false;
+
 var ASSET_PATH = 'assets/images/uml/';
 
 function processBlock(blk) {
@@ -63,6 +65,12 @@ module.exports = {
             if (!Object.keys(this.book.config.get('pluginsConfig.uml', {})).length) {
                 this.book.config.set('pluginsConfig.uml', {
                     format: 'png'
+                });
+            }
+            var startNailgun = this.book.config.get('plugins.uml.nailgun', false);
+            if (startNailgun && !nailgunRunning) {
+                plantuml.useNailgun(function() {
+                    nailgunRunning = true;
                 });
             }
         },


### PR DESCRIPTION
When the number of diagrams increases the time it takes `gitbook` to _serve_ or _build_ a book increases linearly. This affects the experience especially badly when `gitbook` serves a directory since the entire book along with the diagrams are generated on every save.

A have added two new features make me (and hopefully others) happy again:

1. _**Assets are now cached**_
   If an image already exists the PlantUML `java` process never gets invoked.
2. _**Nailgun support**_
  A new option, which is _false_ by default, has been added:
```
     "uml": {
         ...,
        nailgun: true,
        ...
    }
```

I probably should have created two separate pull requests but I hope you will consider merging both features to your fine plugin.

Best regards
GIsli