### PR TITLE
Add support for block src argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ Also you can put in your book block as
 {% enduml %}
 ```
 
+The block syntax also allows for a `src` attribute to import an external PlantUml file. 
+
+```
+{% uml src="test.plantuml" %}{% enduml %}
+```
+
 ## Configuration
 
 book.json add the uml options

--- a/index.js
+++ b/index.js
@@ -13,7 +13,14 @@ function processBlock(blk) {
     var deferred = Q.defer();
 
     var book = this;
-    var code = blk.body;
+
+    var code;
+    if (!!blk.kwargs.src) {
+        code = fs.readFileSync(blk.kwargs.src , "utf8");
+    } else {
+        code = blk.body;
+    }
+
     var config = book.config.get('pluginsConfig.uml', {});
 
     if (blk.kwargs['config']) {

--- a/test/index.js
+++ b/test/index.js
@@ -44,4 +44,17 @@ describe('uml', function() {
                 assert.equal(result[0].content, '<p><img src="assets/images/uml/39e6cfed5bc41c359e02bb07bcfcbcb365bd61eb.png"></p>')
             });
     });
+    it('should correctly use external plantuml file specified by {% uml src="" %} and enduml {% enduml %} tag', function() {
+        return tester.builder()
+            .withContent('\n{% uml src="test/test.plantuml"%}{% enduml %}')
+            .withLocalPlugin(path.join(__dirname, '..'))
+            .withBookJson({
+                gitbook: pkg.engines.gitbook,
+                plugins: ['uml']
+            })
+            .create()
+            .then(function(result) {
+                assert.equal(result[0].content, '<p><img src="assets/images/uml/5e39e6908033eaefb9e853d01eb7f2462a7ea69c.png"></p>')
+            });
+    });
 });

--- a/test/test.plantuml
+++ b/test/test.plantuml
@@ -1,0 +1,3 @@
+@startuml
+(A)->(B)
+@enduml


### PR DESCRIPTION
This allows to import PlantUML files from external files which makes it easier to manage and re-use UML files.

```
{% uml src="test.plantuml" %}{% enduml %}
```