### PR TITLE
Fix generate svg format for pdf book

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,6 +85,15 @@ module.exports = {
                     nailgunRunning = true;
                 });
             }
+
+            // Copy images to output folder every time
+            var book = this;
+            var output = book.output;
+            var rootPath = output.root();
+            if (fs.existsSync(ASSET_PATH)) {
+                fs.mkdirs(path.join(rootPath, ASSET_PATH));
+                fs.copySync(ASSET_PATH, path.join(rootPath, ASSET_PATH));
+            }
         },
 
         // This is called after the book generation
@@ -94,20 +103,6 @@ module.exports = {
 
         // Before the end of book generation
         "finish:before": function() {
-            // Copy images to output folder every time
-            var book = this;
-            var output = book.output;
-            var rootPath = output.root();
-            if (fs.existsSync(ASSET_PATH)) {
-                fs.mkdirs(path.join(rootPath, ASSET_PATH));
-                // fs.copy(ASSET_PATH, path.join(rootPath, ASSET_PATH), {
-                //     clobber: true
-                // }, function(err) {
-                //     if (err)
-                //         console.error(err)
-                // })
-                fs.copySync(ASSET_PATH, path.join(rootPath, ASSET_PATH));
-            }
         },
 
         // The following hooks are called for each page of the book


### PR DESCRIPTION
Need svg files at build pages in `gitbook pdf` directory.

Moved assets copy process `finish:before` hook to `init` hook.

## Found error

```bash
doc (branch) X $ nodenv exec gitbook pdf

...

error: error while generating page "xxx/yyy_page.md":

FileNotFoundError: No "/var/folders/cj/_jc_cv4s42714h644b04x26m0000gn/T/tmp-2105266PALmP6KLZC/assets/images/uml/8407df7f451683c30e28989d828e0569ff91d8f5.svg" file (or is ignored)
```

Not generated assets files(plantuml files) in `/var/folders/cj/_jc_cv4s42714h644b04x26m0000gn/T/tmp-2105266PALmP6KLZC/` directory.

so, I found `finish:before` hooks, but need files at generate pages.


### Fix it

Success pdf book. use svg format PlantUML images.

```bash
doc (branch) X $ nodenv exec gitbook build
info: 9 plugins are installed
info: 8 explicitly listed
info: loading plugin "include-codeblock"...
OK
info: loading plugin "uml"... OK
info: loading plugin "highlight"... OK
info: loading plugin "search"... OK
info: loading plugin "lunr"... OK
info: loading plugin "sharing"... OK
info: loading plugin "fontsettings"... OK
info: loading plugin "theme-default"... OK
info: found 20 pages
info: found 19 asset files
info: >> generation finished with success in 10.1s !

doc (branch) X $ nodenv exec gitbook pdf
info: 9 plugins are installed
info: 8 explicitly listed
info: loading plugin "include-codeblock"...
warn: ace features disabled (`gitbook-plugin-ace` required)
OK
info: loading plugin "uml"... OK
info: loading plugin "highlight"... OK
info: loading plugin "search"... OK
info: loading plugin "lunr"... OK
info: loading plugin "sharing"... OK
info: loading plugin "fontsettings"... OK
info: loading plugin "theme-default"... OK
info: found 20 pages
info: found 19 asset files
info: >> generation finished with success in 10.6s !
info: >> 1 file(s) generated
```